### PR TITLE
Added the forward_to_syslog option to cpcd.conf.

### DIFF
--- a/cpcd.conf
+++ b/cpcd.conf
@@ -80,6 +80,12 @@ trace_to_file: false
 # Folder mounted on a tmpfs is preferred
 traces_folder: /dev/shm/cpcd-traces
 
+# This option allows, when trace_to_file is enabled,
+# to send logs to syslog; however, writing to the file is not performed.
+# Optional, defaults to 'false'
+# Allowed values are 'true' or 'false'
+forward_to_syslog: false
+
 # Number of open file descriptors.
 # Optional, defaults to 2000
 # If the error 'Too many open files' occurs, this is the value to increase.

--- a/include/cpcd/config.h
+++ b/include/cpcd/config.h
@@ -77,6 +77,7 @@ typedef struct __attribute__((packed)) {
 
   cpc_trace_level_t trace_level;
   bool file_tracing;
+  bool forward_to_syslog;
   int lttng_tracing;
   const char *traces_folder;
 

--- a/include/cpcd/logging.h
+++ b/include/cpcd/logging.h
@@ -48,7 +48,7 @@ typedef struct {
 
 void logging_init(void);
 
-void init_file_logging(void);
+void init_file_logging(bool forward_to_syslog);
 
 void init_stats_logging(void);
 

--- a/misc/config.c
+++ b/misc/config.c
@@ -76,6 +76,7 @@ config_t config = {
 
   .trace_level = CPC_TRACE_LEVEL_INFO,
   .file_tracing = true, // Set to true to have the chance to catch early traces. It will be set to false after config file parsing.
+  .forward_to_syslog = false,
   .lttng_tracing = false,
   .traces_folder = "/dev/shm/cpcd-traces", // must be mounted on a tmpfs
 
@@ -364,6 +365,7 @@ static void config_print(cpc_trace_level_t trace_level)
 
   CONFIG_PRINT_TRACE_LEVEL_TO_STR(config.trace_level, trace_level);
   CONFIG_PRINT_BOOL_TO_STR(config.file_tracing);
+  CONFIG_PRINT_BOOL_TO_STR(config.forward_to_syslog);
   CONFIG_PRINT_BOOL_TO_STR(config.lttng_tracing);
   CONFIG_PRINT_STR(config.traces_folder);
 
@@ -1006,6 +1008,14 @@ static cpc_trace_level_t config_parse_config_file(void)
       } else {
         FATAL("Config file error : bad trace_to_file value");
       }
+    } else if (0 == strcmp(name, "forward_to_syslog")) {
+      if (0 == strcmp(val, "true")) {
+        config.forward_to_syslog = true;
+      } else if (0 == strcmp(val, "false")) {
+        config.forward_to_syslog = false;
+      } else {
+        FATAL("Config file error : bad forward_to_syslog value");
+      }
     } else if (0 == strcmp(name, "trace_level")) {
       if (0 == strcmp(val, "error")) {
         tmp_config_trace_level = CPC_TRACE_LEVEL_ERROR;
@@ -1273,7 +1283,7 @@ static void config_validate_configuration(void)
   }
 
   if (config.file_tracing) {
-    init_file_logging();
+    init_file_logging(config.forward_to_syslog);
   }
 
   if (config.stats_interval > 0) {


### PR DESCRIPTION
Motivation: For resource-constrained embedded devices, we would like to be able to write debug logs to syslog. This would allow us to manage logs through rsyslog, for example, configuring log rotation and controlling log file size. Without enabling trace_to_file, the forward_to_syslog option will not work, but it will not write to a file, only to syslog.